### PR TITLE
New google achievements

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -48,6 +48,7 @@ var Gamecircle = Class(function () {
 
 		var param = {"achievementID":achievementID,"percentSolved":percentSolved || 100};
 
+		achievementID = achievementID.replace('-', '');
 		pluginSend("sendAchievement",param);
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gamecircle",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "devkit": {
     "clientPaths": {
       "gamecircle": "js"


### PR DESCRIPTION
Google play now has hyphens(-) in their ahievement id but amazon does not allow that. Hence we are removing hyphens from any sent achievement id in gamecircle.